### PR TITLE
catalyst-uploader: fix error checking in ParseOSURL

### DIFF
--- a/cmd/catalyst-uploader/catalyst-uploader.go
+++ b/cmd/catalyst-uploader/catalyst-uploader.go
@@ -79,11 +79,11 @@ Args:
 	logger := log.WithField("uri", uri).WithField("timeout", *timeout)
 
 	storageDriver, err := drivers.ParseOSURL(uri, true)
+	if err != nil {
+		logger.WithField("stage", "ParseOSURL").Fatal(err)
+	}
 	// path is passed along with the path when uploading
 	session := storageDriver.NewSession("")
-	if err != nil {
-		logger.WithField("stage", "NewSession").Fatal(err)
-	}
 	ctx := context.Background()
 	resKey, err := session.SaveData(ctx, "", os.Stdin, nil, *timeout)
 	if err != nil {


### PR DESCRIPTION
We did this error checking too late and segfaulted.

Before:
```
# echo "foo" | livepeer-catalyst-uploader 'http://admin:password@localhost:9000/livepeer/foo.txt' -l log.txt -v=6
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xea3286]

goroutine 1 [running]:
main.run()
	/home/iameli/code/catalyst-uploader/cmd/catalyst-uploader/catalyst-uploader.go:83 +0x886
main.main()
	/home/iameli/code/catalyst-uploader/cmd/catalyst-uploader/catalyst-uploader.go:103 +0x19
```
After:
```
# echo "foo" | livepeer-catalyst-uploader 'http://admin:password@localhost:9000/livepeer/foo.txt' -l log.txt -v=6
time="2023-07-20T21:24:28Z" level=fatal msg="unrecognized OS scheme: http" stage=ParseOSURL timeout=10s uri="http://admin:password@localhost:9000/livepeer/foo.txt"
```

(For the record, my mistake was typing `http://` instead of `s3+http://`.