### PR TITLE
For media files just do a simple file write rather than incremental

### DIFF
--- a/core/uploader.go
+++ b/core/uploader.go
@@ -35,6 +35,8 @@ func Upload(input io.Reader, outputURI string, waitBetweenWrites, writeTimeout t
 	}
 
 	if strings.HasSuffix(outputURI, ".ts") || strings.HasSuffix(outputURI, ".mp4") {
+		// For segments we just write them in one go here and return early.
+		// (Otherwise the incremental write logic below caused issues with clipping since it results in partial segments being written.)
 		_, err := session.SaveData(context.Background(), "", input, fields, writeTimeout)
 		return err
 	}


### PR DESCRIPTION
The incremental writes caused issues with clipping since it results in partial segments being written. With this change the whole segment is written in one go.

This was tested locally with box by running a stream and repeatedly running a list objects command to check the file sizes stayed static (vs before where they weren't and would increase with each partial write).