### PR TITLE
Revert "Bump recording object ttl to 10 days (#45)"

### DIFF
--- a/core/uploader.go
+++ b/core/uploader.go
@@ -46,7 +46,7 @@ func Upload(input io.Reader, outputURI string, waitBetweenWrites, writeTimeout t
 	if strings.Contains(outputURI, "gateway.storjshare.io/catalyst-recordings-com") {
 		fields = &drivers.FileProperties{
 			Metadata: map[string]string{
-				"Object-Expires": "+240h", // Objects will be deleted after 10 days
+				"Object-Expires": "+168h", // Objects will be deleted after 7 days
 			},
 		}
 	}


### PR DESCRIPTION
This reverts commit 549ad12b28ca0a5c642a06c2a8c44023fb4ff582.

We should use the option on the access keys instead, and then remove this hack.