### PR TITLE
uploader: reinit TeeReader on upload retry to reset pointer

### DIFF
--- a/core/uploader.go
+++ b/core/uploader.go
@@ -73,11 +73,12 @@ func Upload(input io.Reader, outputURI *url.URL, waitBetweenWrites, writeTimeout
 			return nil, fmt.Errorf("failed to read file")
 		}
 
-		// To count how many bytes we are trying to read then write (upload) to s3 storage
-		teeReader := io.TeeReader(bytes.NewReader(fileContents), byteCounter)
-
 		var out *drivers.SaveDataOutput
 		err = backoff.Retry(func() error {
+			// To count how many bytes we are trying to read then write (upload) to s3 storage
+			teeReader := io.TeeReader(bytes.NewReader(fileContents), byteCounter)
+			byteCounter.Count = 0
+
 			out, err = session.SaveData(context.Background(), "", teeReader, fields, segmentWriteTimeout)
 			if err != nil {
 				glog.Errorf("failed upload attempt for %s (%d bytes): %v", outputURI.Redacted(), byteCounter.Count, err)


### PR DESCRIPTION
On an upload fail and retry, teeReader would not be reset and would point to the end of the buffer being uploaded. We need to reset teeReader to begin reading from the beginning of fileContents again.