### PR TITLE
Add a thumbnail at the stream level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/livepeer/go-tools v0.3.6
 	github.com/peterbourgon/ff v1.7.1
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/sync v0.2.0
 )
 
 require (


### PR DESCRIPTION
We'd have two thumbs with this change:
Existing one - /hls/playbackID/sessionID/source/latest.jpg
New stream level one - /hls/playbackID/latest.jpg

We want to do this to support fishtank's scenario where they have an unreliable connection and so new sessions being created all the time, they want a url they can point to just based on the playbackID.

Tested locally with `cat segment.ts | go run catalyst-uploader.go s3+https://xx:xx@gateway.storjshare.io/catalyst-recordings-monster/hls/foo/session/source/blah.ts`