### PR TITLE
Fix concurrency loop issue with thumbURL

### DIFF
--- a/core/uploader.go
+++ b/core/uploader.go
@@ -232,6 +232,7 @@ func extractThumb(outputURI *url.URL, segment []byte, storageFallbackURLs map[st
 	errGroup := &errgroup.Group{}
 
 	for _, thumbURL := range thumbURLs {
+		thumbURL := thumbURL
 		errGroup.Go(func() error {
 			_, _, err = uploadFileWithBackup(thumbURL, thumbData, fields, 10*time.Second, true, storageFallbackURLs)
 			if err != nil {


### PR DESCRIPTION
Need to redefine the loop variable otherwise routines can end up accessing the same variable: https://go.dev/doc/faq#closures_and_goroutines