### PR TITLE
Add support for a default config file

### DIFF
--- a/catalyst-uploader.go
+++ b/catalyst-uploader.go
@@ -40,7 +40,12 @@ func run() int {
 	timeout := fs.Duration("t", 30*time.Second, "Upload timeout")
 	storageFallbackURLs := CommaMapFlag(fs, "storage-fallback-urls", `Comma-separated map of primary to backup storage URLs. If a file fails uploading to one of the primary storages (detected by prefix), it will fallback to the corresponding backup URL after having the prefix replaced`)
 
-	_ = fs.String("config", "", "config file (optional)")
+	defaultConfigFile := "/etc/livepeer/catalyst_uploader.conf"
+	_, err = os.Stat(defaultConfigFile)
+	if err != nil && os.IsNotExist(err) {
+		defaultConfigFile = ""
+	}
+	_ = fs.String("config", defaultConfigFile, "config file (optional)")
 
 	err = ff.Parse(fs, os.Args[1:],
 		ff.WithConfigFileFlag("config"),

--- a/catalyst-uploader.go
+++ b/catalyst-uploader.go
@@ -41,8 +41,7 @@ func run() int {
 	storageFallbackURLs := CommaMapFlag(fs, "storage-fallback-urls", `Comma-separated map of primary to backup storage URLs. If a file fails uploading to one of the primary storages (detected by prefix), it will fallback to the corresponding backup URL after having the prefix replaced`)
 
 	defaultConfigFile := "/etc/livepeer/catalyst_uploader.conf"
-	_, err = os.Stat(defaultConfigFile)
-	if err != nil && os.IsNotExist(err) {
+	if _, err := os.Stat(defaultConfigFile); os.IsNotExist(err) {
 		defaultConfigFile = ""
 	}
 	_ = fs.String("config", defaultConfigFile, "config file (optional)")


### PR DESCRIPTION
We want to be able to set config without making mist changes and also without cycling pods which is required for environment variable changes. This way we can add the config file to running pods via our existing mechanism and the uploader will pick it up automatically.